### PR TITLE
Fix label overlapping or cropping; allow to override

### DIFF
--- a/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
+++ b/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
@@ -99,6 +99,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     protected double absoluteMinValuePrim, absoluteMaxValuePrim;
     protected double normalizedMinValue = 0d;
     protected double normalizedMaxValue = 1d;
+    protected double minDeltaForDefault = 0;
     private Thumb pressedThumb = null;
     private boolean notifyWhileDragging = false;
     private OnRangeSeekBarChangeListener<T> listener;
@@ -606,7 +607,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
         mRect.right = getWidth() - padding;
         canvas.drawRect(mRect, paint);
 
-        boolean selectedValuesAreDefault = (normalizedMinValue < 0.00001 && normalizedMaxValue > 0.99999);
+        boolean selectedValuesAreDefault = (normalizedMinValue <= minDeltaForDefault && normalizedMaxValue >= 1 - minDeltaForDefault);
 
         int colorToUseForButtonsAndHighlightedLine = !mAlwaysActive && !mActivateOnDefaultValues && selectedValuesAreDefault ?
                 mDefaultColor : // default values


### PR DESCRIPTION
Hi! This resolves two types of issues:
1. If the sliders were close to each other, the value labels overlapped and were hard to read. Also, if a value label was close to the beginning or the end, it was sometimes cut off. This fixes both.
2. I needed a log-scale with units displayed (e.g. min = 1 mm, max = 1 km), but the methods and variables were declared private. This changes the declaration to protected, so that it's easier to use a custom scale (like log-scale in my case), and custom value labels (like adding "km" in my case). (I also had to change an equality check to a more relaxed one, probably because of the log scale.)
