### PR TITLE
Make the type of the argument 'bar' more specific.

### DIFF
--- a/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
+++ b/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
@@ -890,9 +890,9 @@ public class RangeSeekBar<T extends Number> extends ImageView {
      * @param <T> The Number type the RangeSeekBar has been declared with.
      * @author Stephan Tittel (stephan.tittel@kom.tu-darmstadt.de)
      */
-    public interface OnRangeSeekBarChangeListener<T> {
+    public interface OnRangeSeekBarChangeListener<T extends Number> {
 
-        void onRangeSeekBarValuesChanged(RangeSeekBar<?> bar, T minValue, T maxValue);
+        void onRangeSeekBarValuesChanged(RangeSeekBar<T> bar, T minValue, T maxValue);
     }
 
 }


### PR DESCRIPTION
Though it is a minor thing, I believe the type of the argument `bar` in the listener method `org.florescu.android.rangeseekbar.RangeSeekBar#setOnRangeSeekBarChangeListener` can be more specific and it should be.

Currently, if we are accessing the min/max value in the listener method, a cast is required as below:

``` java
RangeSeekBar<Integer> mSeekBar = ...;
mSeekBar.setOnRangeSeekBarChangeListener(new RangeSeekBar.OnRangeSeekBarChangeListener<Integer>() {
    @Override
     public void onRangeSeekBarValuesChanged(RangeSeekBar<?> bar, Integer minValue, Integer maxValue) {
        final Integer max = (Integer) bar.getAbsoluteMaxValue();
        final Integer selectedMax = (Integer) bar.getSelectedMaxValue();
    }
});
```

Instead, we can write as below after this change is applied.

``` java
mSeekBar.setOnRangeSeekBarChangeListener(new RangeSeekBar.OnRangeSeekBarChangeListener<Integer>() {
    @Override
    public void onRangeSeekBarValuesChanged(RangeSeekBar<Integer> bar, Integer minValue, Integer maxValue) {
        final Integer max = bar.getAbsoluteMaxValue();
        final Integer selectedMax = bar.getSelectedMaxValue();
    }
});
```

Feel free to let me know if you have any concerns or there is any background about why using a wildcard type parameter.

Thank you.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/anothem/android-range-seek-bar/59)

<!-- Reviewable:end -->
